### PR TITLE
Add development build

### DIFF
--- a/script/build_jn5189
+++ b/script/build_jn5189
@@ -55,8 +55,13 @@ build()
         ninja
     fi
 
-    "$NXP_JN5189_SDK_ROOT"/tools/imagetool/sign_images.sh openthread/examples/apps/cli/
-    "$NXP_JN5189_SDK_ROOT"/tools/imagetool/sign_images.sh openthread/examples/apps/ncp/
+    if [ "$SDK_RELEASE" == "ON" ]; then
+        "$NXP_JN5189_SDK_ROOT"/tools/imagetool/sign_images.sh openthread/examples/apps/cli/
+        "$NXP_JN5189_SDK_ROOT"/tools/imagetool/sign_images.sh openthread/examples/apps/ncp/
+    else
+        "$NXP_JN5189_SDK_ROOT"/middleware/wireless/openthread/boards/dk6_jn5189/enablement/sign_images.sh openthread/examples/apps/cli/ "$NXP_K32W061_SDK_ROOT"/tools/imagetool
+        "$NXP_JN5189_SDK_ROOT"/middleware/wireless/openthread/boards/dk6_jn5189/enablement/sign_images.sh openthread/examples/apps/ncp/ "$NXP_K32W061_SDK_ROOT"/tools/imagetool
+    fi
 
     cd "${OT_SRCDIR}"
 }

--- a/script/build_k32w061
+++ b/script/build_k32w061
@@ -55,8 +55,13 @@ build()
         ninja
     fi
 
-    "$NXP_K32W061_SDK_ROOT"/tools/imagetool/sign_images.sh openthread/examples/apps/cli/
-    "$NXP_K32W061_SDK_ROOT"/tools/imagetool/sign_images.sh openthread/examples/apps/ncp/
+    if [ "$SDK_RELEASE" == "ON" ]; then
+        "$NXP_K32W061_SDK_ROOT"/tools/imagetool/sign_images.sh openthread/examples/apps/cli/
+        "$NXP_K32W061_SDK_ROOT"/tools/imagetool/sign_images.sh openthread/examples/apps/ncp/
+    else
+        "$NXP_K32W061_SDK_ROOT"/middleware/wireless/openthread/boards/dk6_jn5189/enablement/sign_images.sh openthread/examples/apps/cli/ "$NXP_K32W061_SDK_ROOT"/tools/imagetool
+        "$NXP_K32W061_SDK_ROOT"/middleware/wireless/openthread/boards/dk6_jn5189/enablement/sign_images.sh openthread/examples/apps/ncp/ "$NXP_K32W061_SDK_ROOT"/tools/imagetool
+    fi
 
     cd "${OT_SRCDIR}"
 }

--- a/src/k32w/CMakeLists.txt
+++ b/src/k32w/CMakeLists.txt
@@ -51,7 +51,6 @@ list(APPEND OT_PUBLIC_INCLUDES
         "${PROJECT_SOURCE_DIR}/openthread/third_party/mbedtls/repo/"
         "${PROJECT_SOURCE_DIR}/openthread/third_party/mbedtls/repo/include/"
         "$ENV{NXP_K32W061_SDK_ROOT}"
-        "$ENV{NXP_K32W061_SDK_ROOT}/boards/k32w061dk6/wireless_examples/openthread/enablement"
         "$ENV{NXP_K32W061_SDK_ROOT}/CMSIS/Include/"
         "$ENV{NXP_K32W061_SDK_ROOT}/components/serial_manager/"
         "$ENV{NXP_K32W061_SDK_ROOT}/devices/K32W061"
@@ -73,6 +72,27 @@ list(APPEND OT_PUBLIC_INCLUDES
         "$ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/framework/XCVR/DK6/Build/Include"
 )
 
+if (SDK_RELEASE)
+    list(APPEND OT_PUBLIC_INCLUDES
+        "$ENV{NXP_K32W061_SDK_ROOT}/boards/k32w061dk6/wireless_examples/openthread/enablement"
+    )
+else()
+    list(APPEND OT_PUBLIC_INCLUDES
+        "$ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/openthread/boards/dk6_jn5189/enablement"
+        "$ENV{NXP_K32W061_SDK_ROOT}/platform/drivers/aes"
+        "$ENV{NXP_K32W061_SDK_ROOT}/platform/drivers/common"
+        "$ENV{NXP_K32W061_SDK_ROOT}/platform/drivers/ctimer"
+        "$ENV{NXP_K32W061_SDK_ROOT}/platform/drivers/flexcomm"
+        "$ENV{NXP_K32W061_SDK_ROOT}/platform/drivers/jn_flash"
+        "$ENV{NXP_K32W061_SDK_ROOT}/platform/drivers/jn_iocon"
+        "$ENV{NXP_K32W061_SDK_ROOT}/platform/drivers/jn_rng"
+        "$ENV{NXP_K32W061_SDK_ROOT}/platform/drivers/lpc_adc"
+        "$ENV{NXP_K32W061_SDK_ROOT}/platform/drivers/lpc_gpio"
+        "$ENV{NXP_K32W061_SDK_ROOT}/platform/drivers/sha"
+        "$ENV{NXP_K32W061_SDK_ROOT}/platform/utilities/debug_console"
+    )
+endif()
+
 set(K32W_COMM_SOURCES
     platform/alarm.c
     platform/diag.c
@@ -84,10 +104,19 @@ set(K32W_COMM_SOURCES
     platform/settings_k32w.c
     platform/system.c
     platform/uart.c
-    $ENV{NXP_K32W061_SDK_ROOT}/devices/K32W061/utilities/fsl_assert.c
     $ENV{NXP_K32W061_SDK_ROOT}/middleware/mbedtls/port/ksdk/aes_alt.c
     $ENV{NXP_K32W061_SDK_ROOT}/middleware/mbedtls/port/ksdk/ksdk_mbedtls.c
 )
+
+if (SDK_RELEASE)
+    list(APPEND K32W_COMM_SOURCES
+        $ENV{NXP_K32W061_SDK_ROOT}/devices/K32W061/utilities/fsl_assert.c
+    )
+else()
+    list(APPEND K32W_COMM_SOURCES
+        $ENV{NXP_K32W061_SDK_ROOT}/platform/utilities/assert/fsl_assert.c
+    )
+endif()
 
 set(K32W_LIBS
     $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/ieee-802.15.4/lib/libMiniMac.a

--- a/src/k32w/jn5189/jn5189.ld
+++ b/src/k32w/jn5189/jn5189.ld
@@ -82,7 +82,7 @@ INT_STORAGE_SIZE                               = INT_STORAGE_END - INT_STORAGE_S
 
 FREESCALE_PROD_DATA_BASE_ADDR                  = m_fsl_prodInfo_start;
 INT_STORAGE_SECTOR_SIZE                        = m_sector_size;
-m_app_size                                     = 0x7A120;
+m_app_size                                     = 0x96000;
 __ram_vector_table__                           = 1;
 vector_table_size                              = 0x120;
 M_VECTOR_RAM_SIZE                              = DEFINED(__ram_vector_table__) ? vector_table_size : 0x0;

--- a/src/k32w/k32w061/k32w061.ld
+++ b/src/k32w/k32w061/k32w061.ld
@@ -82,7 +82,7 @@ INT_STORAGE_SIZE                               = INT_STORAGE_END - INT_STORAGE_S
 
 FREESCALE_PROD_DATA_BASE_ADDR                  = m_fsl_prodInfo_start;
 INT_STORAGE_SECTOR_SIZE                        = m_sector_size;
-m_app_size                                     = 0x7A120;
+m_app_size                                     = 0x96000;
 __ram_vector_table__                           = 1;
 vector_table_size                              = 0x120;
 M_VECTOR_RAM_SIZE                              = DEFINED(__ram_vector_table__) ? vector_table_size : 0x0;

--- a/third_party/jn5189_sdk/CMakeLists.txt
+++ b/third_party/jn5189_sdk/CMakeLists.txt
@@ -67,10 +67,45 @@ if (SDK_RELEASE)
         $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/framework/TimersManager/Source/TMR_Adapter.c
     )
     else()
-    SET_SOURCE_FILES_PROPERTIES( $ENV{NXP_JN5189_SDK_ROOT}/path_from_repo/TODO.c PROPERTIES LANGUAGE CXX)
+
+    SET_SOURCE_FILES_PROPERTIES($ENV{NXP_JN5189_SDK_ROOT}/devices/JN5189/mcuxpresso/startup_jn5189.c PROPERTIES LANGUAGE CXX)
     
     add_library(nxp-jn5189-driver
-        $ENV{NXP_JN5189_SDK_ROOT}/path_from_repo/TODO.c
+        $ENV{NXP_K32W061_SDK_ROOT}/boards/k32w061dk6/utility/board_utility.c
+        $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/openthread/boards/dk6_jn5189/enablement/board.c
+        $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/openthread/boards/dk6_jn5189/enablement/clock_config.c
+        $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/openthread/boards/dk6_jn5189/enablement/pin_mux.c
+        $ENV{NXP_JN5189_SDK_ROOT}/components/serial_manager/serial_manager.c
+        $ENV{NXP_JN5189_SDK_ROOT}/components/serial_manager/serial_port_uart.c
+        $ENV{NXP_JN5189_SDK_ROOT}/components/uart/usart_adapter.c
+        $ENV{NXP_JN5189_SDK_ROOT}/devices/K32W061/drivers/fsl_clock.c
+        $ENV{NXP_JN5189_SDK_ROOT}/devices/K32W061/drivers/fsl_power.c
+        $ENV{NXP_JN5189_SDK_ROOT}/devices/K32W061/drivers/fsl_reset.c
+        $ENV{NXP_JN5189_SDK_ROOT}/devices/K32W061/drivers/fsl_wtimer.c
+        $ENV{NXP_JN5189_SDK_ROOT}/devices/JN5189/system_JN5189.c
+        $ENV{NXP_JN5189_SDK_ROOT}/devices/JN5189/mcuxpresso/startup_jn5189.c
+        $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/framework/Common/MicroInt_arm_sdk2.c
+        $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/framework/Flash/Internal/Flash_Adapter.c
+        $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/framework/FunctionLib/FunctionLib.c
+        $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/framework/Lists/GenericList.c
+        $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/framework/MemManager/Source/MemManager.c
+        $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/framework/Panic/Source/Panic.c
+        $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/framework/PDM/pdm_port.c
+        $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/framework/Reset/Reset.c
+        $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/framework/SerialManager/Source/SerialManager.c
+        $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/framework/SerialManager/Source/UART_Serial_Adapter.c
+        $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/framework/TimersManager/Source/TMR_Adapter.c
+        $ENV{NXP_JN5189_SDK_ROOT}/platform/drivers/aes/fsl_aes.c
+        $ENV{NXP_JN5189_SDK_ROOT}/platform/drivers/common/fsl_common.c
+        $ENV{NXP_JN5189_SDK_ROOT}/platform/drivers/ctimer/fsl_ctimer.c
+        $ENV{NXP_JN5189_SDK_ROOT}/platform/drivers/flexcomm/fsl_flexcomm.c
+        $ENV{NXP_JN5189_SDK_ROOT}/platform/drivers/flexcomm/fsl_usart.c
+        $ENV{NXP_JN5189_SDK_ROOT}/platform/drivers/lpc_gpio/fsl_gpio.c
+        $ENV{NXP_JN5189_SDK_ROOT}/platform/drivers/jn_flash/fsl_flash.c
+        $ENV{NXP_JN5189_SDK_ROOT}/platform/drivers/jn_rng/fsl_rng.c
+        $ENV{NXP_JN5189_SDK_ROOT}/platform/drivers/sha/fsl_sha.c
+        $ENV{NXP_JN5189_SDK_ROOT}/platform/utilities/debug_console/fsl_debug_console.c
+        $ENV{NXP_JN5189_SDK_ROOT}/platform/utilities/debug_console/str/fsl_str.c
     )
 endif()
 
@@ -109,8 +144,8 @@ if (SDK_RELEASE)
             $ENV{NXP_JN5189_SDK_ROOT}/CMSIS/Include  
             $ENV{NXP_JN5189_SDK_ROOT}/components/uart
             $ENV{NXP_JN5189_SDK_ROOT}/devices/JN5189
-            $ENV{NXP_JN5189_SDK_ROOT}/devices/JN5189/drivers 
-            $ENV{NXP_JN5189_SDK_ROOT}/devices/JN5189/utilities/str 
+            $ENV{NXP_JN5189_SDK_ROOT}/devices/K32W061/drivers 
+            $ENV{NXP_JN5189_SDK_ROOT}/devices/K32W061/utilities/str 
             $ENV{NXP_JN5189_SDK_ROOT}/middleware/mbedtls/port/ksdk       
             $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/ieee-802.15.4/uMac/Include
             $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/framework/Common/
@@ -131,7 +166,29 @@ if (SDK_RELEASE)
     else()
     target_include_directories(nxp-jn5189-driver
         PUBLIC
-            $ENV{NXP_JN5189_SDK_ROOT}/path_from_repo/TODO.c
+            $ENV{NXP_JN5189_SDK_ROOT}/boards/jn5189dk6/wireless_examples/openthread/enablement
+            $ENV{NXP_JN5189_SDK_ROOT}/components/serial_manager
+            $ENV{NXP_JN5189_SDK_ROOT}/CMSIS/Include
+            $ENV{NXP_JN5189_SDK_ROOT}/components/uart
+            $ENV{NXP_JN5189_SDK_ROOT}/devices/JN5189
+            $ENV{NXP_JN5189_SDK_ROOT}/devices/JN5189/drivers
+            $ENV{NXP_JN5189_SDK_ROOT}/middleware/mbedtls/port/ksdk
+            $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/ieee-802.15.4/uMac/Include
+            $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/framework/Common/
+            $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/framework/FunctionLib/
+            $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/framework/Flash/Internal
+            $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/framework/Lists
+            $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/framework/MemManager/Interface
+            $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/framework/OSAbstraction/Interface
+            $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/framework/Panic/Interface/
+            $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/framework/PDM/Include
+            $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/framework/SerialManager/Interface
+            $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/framework/SerialManager/Source
+            $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/framework/TimersManager/Interface
+            $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/framework/TimersManager/Source
+            $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/framework/XCVR/DK6/Build/Include
+            $ENV{NXP_JN5189_SDK_ROOT}/middleware/wireless/framework/XCVR/DK6
+            $ENV{NXP_JN5189_SDK_ROOT}/platform/utilities/debug_console/str
     )
 endif()
 

--- a/third_party/k32w061_sdk/CMakeLists.txt
+++ b/third_party/k32w061_sdk/CMakeLists.txt
@@ -41,8 +41,8 @@ if (SDK_RELEASE)
         $ENV{NXP_K32W061_SDK_ROOT}/devices/K32W061/system_K32W061.c
         $ENV{NXP_K32W061_SDK_ROOT}/devices/K32W061/drivers/fsl_aes.c
         $ENV{NXP_K32W061_SDK_ROOT}/devices/K32W061/drivers/fsl_clock.c 
-        $ENV{NXP_K32W061_SDK_ROOT}/devices/K32W061/drivers/fsl_common.c
         $ENV{NXP_K32W061_SDK_ROOT}/devices/K32W061/drivers/fsl_ctimer.c
+        $ENV{NXP_K32W061_SDK_ROOT}/devices/K32W061/drivers/fsl_common.c
         $ENV{NXP_K32W061_SDK_ROOT}/devices/K32W061/drivers/fsl_flash.c   
         $ENV{NXP_K32W061_SDK_ROOT}/devices/K32W061/drivers/fsl_flexcomm.c 
         $ENV{NXP_K32W061_SDK_ROOT}/devices/K32W061/drivers/fsl_gpio.c
@@ -67,10 +67,45 @@ if (SDK_RELEASE)
         $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/framework/TimersManager/Source/TMR_Adapter.c
     )
     else()
-    SET_SOURCE_FILES_PROPERTIES( $ENV{NXP_K32W061_SDK_ROOT}/path_from_repo/TODO.c PROPERTIES LANGUAGE CXX)
+
+    SET_SOURCE_FILES_PROPERTIES($ENV{NXP_K32W061_SDK_ROOT}/devices/K32W061/mcuxpresso/startup_k32w061.c PROPERTIES LANGUAGE CXX)
     
     add_library(nxp-k32w061-driver
-        $ENV{NXP_K32W061_SDK_ROOT}/path_from_repo/TODO.c
+        $ENV{NXP_K32W061_SDK_ROOT}/boards/k32w061dk6/utility/board_utility.c
+        $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/openthread/boards/dk6_jn5189/enablement/board.c
+        $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/openthread/boards/dk6_jn5189/enablement/clock_config.c
+        $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/openthread/boards/dk6_jn5189/enablement/pin_mux.c
+        $ENV{NXP_K32W061_SDK_ROOT}/components/serial_manager/serial_manager.c
+        $ENV{NXP_K32W061_SDK_ROOT}/components/serial_manager/serial_port_uart.c
+        $ENV{NXP_K32W061_SDK_ROOT}/components/uart/usart_adapter.c
+        $ENV{NXP_K32W061_SDK_ROOT}/devices/K32W061/drivers/fsl_clock.c
+        $ENV{NXP_K32W061_SDK_ROOT}/devices/K32W061/drivers/fsl_power.c
+        $ENV{NXP_K32W061_SDK_ROOT}/devices/K32W061/drivers/fsl_reset.c
+        $ENV{NXP_K32W061_SDK_ROOT}/devices/K32W061/drivers/fsl_wtimer.c
+        $ENV{NXP_K32W061_SDK_ROOT}/devices/K32W061/system_K32W061.c
+        $ENV{NXP_K32W061_SDK_ROOT}/devices/K32W061/mcuxpresso/startup_k32w061.c
+        $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/framework/Common/MicroInt_arm_sdk2.c
+        $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/framework/Flash/Internal/Flash_Adapter.c
+        $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/framework/FunctionLib/FunctionLib.c
+        $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/framework/Lists/GenericList.c
+        $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/framework/MemManager/Source/MemManager.c
+        $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/framework/Panic/Source/Panic.c
+        $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/framework/PDM/pdm_port.c
+        $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/framework/Reset/Reset.c
+        $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/framework/SerialManager/Source/SerialManager.c
+        $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/framework/SerialManager/Source/UART_Serial_Adapter.c
+        $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/framework/TimersManager/Source/TMR_Adapter.c
+        $ENV{NXP_K32W061_SDK_ROOT}/platform/drivers/aes/fsl_aes.c
+        $ENV{NXP_K32W061_SDK_ROOT}/platform/drivers/common/fsl_common.c
+        $ENV{NXP_K32W061_SDK_ROOT}/platform/drivers/ctimer/fsl_ctimer.c
+        $ENV{NXP_K32W061_SDK_ROOT}/platform/drivers/flexcomm/fsl_flexcomm.c
+        $ENV{NXP_K32W061_SDK_ROOT}/platform/drivers/flexcomm/fsl_usart.c
+        $ENV{NXP_K32W061_SDK_ROOT}/platform/drivers/lpc_gpio/fsl_gpio.c
+        $ENV{NXP_K32W061_SDK_ROOT}/platform/drivers/jn_flash/fsl_flash.c
+        $ENV{NXP_K32W061_SDK_ROOT}/platform/drivers/jn_rng/fsl_rng.c
+        $ENV{NXP_K32W061_SDK_ROOT}/platform/drivers/sha/fsl_sha.c
+        $ENV{NXP_K32W061_SDK_ROOT}/platform/utilities/debug_console/fsl_debug_console.c
+        $ENV{NXP_K32W061_SDK_ROOT}/platform/utilities/debug_console/str/fsl_str.c
     )
 endif()
 
@@ -131,7 +166,29 @@ if (SDK_RELEASE)
     else()
     target_include_directories(nxp-k32w061-driver
         PUBLIC
-            $ENV{NXP_K32W061_SDK_ROOT}/path_from_repo/TODO.c
+            $ENV{NXP_K32W061_SDK_ROOT}/boards/k32w061dk6/wireless_examples/openthread/enablement
+            $ENV{NXP_K32W061_SDK_ROOT}/components/serial_manager
+            $ENV{NXP_K32W061_SDK_ROOT}/CMSIS/Include
+            $ENV{NXP_K32W061_SDK_ROOT}/components/uart
+            $ENV{NXP_K32W061_SDK_ROOT}/devices/K32W061
+            $ENV{NXP_K32W061_SDK_ROOT}/devices/K32W061/drivers
+            $ENV{NXP_K32W061_SDK_ROOT}/middleware/mbedtls/port/ksdk
+            $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/ieee-802.15.4/uMac/Include
+            $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/framework/Common/
+            $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/framework/FunctionLib/
+            $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/framework/Flash/Internal
+            $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/framework/Lists
+            $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/framework/MemManager/Interface
+            $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/framework/OSAbstraction/Interface
+            $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/framework/Panic/Interface/
+            $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/framework/PDM/Include
+            $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/framework/SerialManager/Interface
+            $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/framework/SerialManager/Source
+            $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/framework/TimersManager/Interface
+            $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/framework/TimersManager/Source
+            $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/framework/XCVR/DK6/Build/Include
+            $ENV{NXP_K32W061_SDK_ROOT}/middleware/wireless/framework/XCVR/DK6
+            $ENV{NXP_K32W061_SDK_ROOT}/platform/utilities/debug_console/str
     )
 endif()
 


### PR DESCRIPTION
There are two ways for compiling NXP demo applications: using an SDK downloaded from MCUX or using the internal repositories. This commit adds support for using directly the internal repositories. (paths from a released SDKs and from the internal repositories are different in some cases).