### PR TITLE
[config] guard OPENTHREAD_CONFIG_PING_SENDER_ENABLE

### DIFF
--- a/src/imx_rt/rt1060/openthread-core-rt1060-config.h
+++ b/src/imx_rt/rt1060/openthread-core-rt1060-config.h
@@ -260,7 +260,9 @@ LOG_MODULE_DEFINE(ot_stack_log, kLOG_LevelDebug)
  * Enable Ping sender functionnality
  *
  */
+#ifndef OPENTHREAD_CONFIG_PING_SENDER_ENABLE
 #define OPENTHREAD_CONFIG_PING_SENDER_ENABLE 1
+#endif
 
 /**
  * @def OPENTHREAD_CONFIG_THREAD_VERSION


### PR DESCRIPTION
It is defined multiple times in NXP build.