### PR TITLE
k32w0: new features and fixes and switch to SDK 2.6.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,11 +95,10 @@ jobs:
         sudo pip3 install pycrypto
         sudo pip3 install pycryptodome
         cmake --version | grep 3.10.3
-        mkdir -p sdk_k32w061 
-        cd sdk_k32w061
-        wget https://cache.nxp.com/lgfiles/bsps/SDK_2_6_6_K32W061DK6.zip
-        unzip SDK_2_6_6_K32W061DK6.zip
-        rm -rf SDK_2_6_6_K32W061DK6.zip
+        wget https://cache.nxp.com/lgfiles/bsps/SDK_2_6_7_K32W061DK6.zip
+        unzip SDK_2_6_7_K32W061DK6.zip
+        rm -rf SDK_2_6_7_K32W061DK6.zip
+        mv -f SDK_2_6_7_K32W061DK6 sdk_k32w061
         cd /tmp
         mkdir -p sdk_jn5189
         cd sdk_jn5189

--- a/src/k32w0/jn5189/openthread-core-jn5189-config.h
+++ b/src/k32w0/jn5189/openthread-core-jn5189-config.h
@@ -327,7 +327,7 @@
  *
  */
 #undef OPENTHREAD_CONFIG_MAC_CSL_AUTO_SYNC_ENABLE
-#define OPENTHREAD_CONFIG_MAC_CSL_AUTO_SYNC_ENABLE OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+#define OPENTHREAD_CONFIG_MAC_CSL_AUTO_SYNC_ENABLE 0
 
 /* The  accuracy, in units of +- ppm, of the clock used for scheduling CSL operations */
 #define CONFIG_PLATFORM_CSL_ACCURACY 100
@@ -340,7 +340,7 @@
  *
  */
 #ifndef OPENTHREAD_CONFIG_CSL_RECEIVE_TIME_AHEAD
-#define OPENTHREAD_CONFIG_CSL_RECEIVE_TIME_AHEAD 320
+#define OPENTHREAD_CONFIG_CSL_RECEIVE_TIME_AHEAD 1920
 #endif
 
 /**
@@ -369,4 +369,74 @@
 #define OPENTHREAD_CONFIG_MAC_CSL_REQUEST_AHEAD_US 2000
 #endif
 
+/* Thread 1.3 configuration flags */
+/**
+ * @def OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
+ *
+ * Define to 1 to enable DNS Client support.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
+#define OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE 1
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE
+ *
+ * Define to 1 to enable DNS-SD Server support.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE
+#define OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE 1
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
+ *
+ * Define to 1 to enable SRP Client support.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
+#define OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE 1
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
+ *
+ * Define to 1 to enable SRP Server support.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
+#define OPENTHREAD_CONFIG_SRP_SERVER_ENABLE 1
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+ *
+ * Define to 1 to support injecting Service entries into the Thread Network Data.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+#define OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE 1
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_ECDSA_ENABLE
+ *
+ * Define to 1 to enable ECDSA support.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_ECDSA_ENABLE
+#define OPENTHREAD_CONFIG_ECDSA_ENABLE 1
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+ *
+ * Define to 1 to enable Thread Test Harness reference device support.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+#define OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE 1
+#endif
 #endif // OPENTHREAD_CORE_JN5189_CONFIG_H_

--- a/src/k32w0/k32w061/openthread-core-k32w061-config.h
+++ b/src/k32w0/k32w061/openthread-core-k32w061-config.h
@@ -317,7 +317,7 @@
  *
  */
 #undef OPENTHREAD_CONFIG_MAC_CSL_AUTO_SYNC_ENABLE
-#define OPENTHREAD_CONFIG_MAC_CSL_AUTO_SYNC_ENABLE OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+#define OPENTHREAD_CONFIG_MAC_CSL_AUTO_SYNC_ENABLE 0
 
 /* The  accuracy, in units of +- ppm, of the clock used for scheduling CSL operations */
 #define CONFIG_PLATFORM_CSL_ACCURACY 100
@@ -330,7 +330,7 @@
  *
  */
 #ifndef OPENTHREAD_CONFIG_CSL_RECEIVE_TIME_AHEAD
-#define OPENTHREAD_CONFIG_CSL_RECEIVE_TIME_AHEAD 320
+#define OPENTHREAD_CONFIG_CSL_RECEIVE_TIME_AHEAD 1920
 #endif
 
 /**
@@ -367,5 +367,76 @@
  */
 #ifndef OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE
 #define OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE 0
+#endif
+
+/* Thread 1.3 configuration flags */
+/**
+ * @def OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
+ *
+ * Define to 1 to enable DNS Client support.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
+#define OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE 1
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE
+ *
+ * Define to 1 to enable DNS-SD Server support.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE
+#define OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE 1
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
+ *
+ * Define to 1 to enable SRP Client support.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
+#define OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE 1
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
+ *
+ * Define to 1 to enable SRP Server support.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
+#define OPENTHREAD_CONFIG_SRP_SERVER_ENABLE 1
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+ *
+ * Define to 1 to support injecting Service entries into the Thread Network Data.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+#define OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE 1
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_ECDSA_ENABLE
+ *
+ * Define to 1 to enable ECDSA support.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_ECDSA_ENABLE
+#define OPENTHREAD_CONFIG_ECDSA_ENABLE 1
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+ *
+ * Define to 1 to enable Thread Test Harness reference device support.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+#define OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE 1
 #endif
 #endif // OPENTHREAD_CORE_K32W061_CONFIG_H_

--- a/src/k32w0/platform/alarm.c
+++ b/src/k32w0/platform/alarm.c
@@ -355,6 +355,10 @@ uint32_t otPlatAlarmMicroGetNow(void)
 
 uint64_t otPlatTimeGet(void)
 {
+    OSA_InterruptDisable();
+
+    uint64_t us_tstp = 0;
+
     /* Make the us timestamp wrap around on 64-bit */
     uint32_t tstp = Timestamp_GetCounter32bit();
 
@@ -364,6 +368,9 @@ uint64_t otPlatTimeGet(void)
         tstp_ovf += OVF_32bit_US;
     }
     prev_tstp = tstp;
+    us_tstp   = TICKS32kHz_TO_USEC(tstp) + tstp_ovf;
 
-    return TICKS32kHz_TO_USEC(tstp) + tstp_ovf;
+    OSA_InterruptEnable();
+
+    return us_tstp;
 }

--- a/src/k32w0/platform/pdm_ram_storage_glue.c
+++ b/src/k32w0/platform/pdm_ram_storage_glue.c
@@ -44,7 +44,7 @@
 
 #if !ENABLE_STORAGE_DYNAMIC_MEMORY
 #ifndef PDM_BUFFER_SIZE
-#define PDM_BUFFER_SIZE 512
+#define PDM_BUFFER_SIZE (1024 + sizeof(ramBufferDescriptor)) /* kRamBufferInitialSize is 1024 */
 #endif
 static uint8_t sPdmBuffer[PDM_BUFFER_SIZE] __attribute__((aligned(4))) = {0};
 #endif
@@ -138,8 +138,8 @@ ramBufferDescriptor *getRamBuffer(uint16_t nvmId, uint16_t initialSize)
     ramBufferDescriptor *ramDescr  = (ramBufferDescriptor *)&sPdmBuffer;
     uint16_t             bytesRead = 0;
 
-    assert(initialSize <= PDM_BUFFER_SIZE);
-    ramDescr->ramBufferMaxLen = PDM_BUFFER_SIZE;
+    ramDescr->ramBufferMaxLen = PDM_BUFFER_SIZE - offsetof(ramBufferDescriptor, pRamBuffer);
+    assert(initialSize <= ramDescr->ramBufferMaxLen);
 
     if (PDM_bDoesDataExist(nvmId, &bytesRead))
     {


### PR DESCRIPTION
```
- enable Thread 1.3 configuration flags

- fix pdm_ram_storage_glue to avoid assert()

- uart: implement otPlatUartFlush() to avoid message truncation on console print
        add flush timeout: wait up to 500ms in otPlatUartFlush()

- entropy: add mutex in otPlatEntropyGet() since it's used by both Matter and Openthread
           to gather entropy through HW TRNG.

- alarm: switch to 32bit WTIMER in otPlatTimeGet()
         Use Timestamp_GetCounter32bit() instead of Timestamp_GetCounter64bit() to
         avoid the race condition when reading the log and high part of WTIMER_TIMER0

- radio:
    fix source address match
     enable address match so FP=0 for SED.
      Address match is disabled only when address table is full.
      See SourceMatchController::AddEntry()

     set size of address table(s) to
      MIN(OPENTHREAD_CONFIG_MLE_MAX_CHILDREN, the size of address mask variable(s) = 64)
      to avoid address table(s) to fill up

    add OT_RADIO_CAPS_CSMA_BACKOFF, OT_RADIO_CAPS_SLEEP_TO_TX

    trx state machine update
     don't restart Rx on the same channel
      prevent Rx restart if it's already in Rx on the same channel
      always start Rx with a new frame

     allow Rx in any state
      allow Rx to finsh in any state
      after Rx done, restart Rx only if in receive state

     radio stop before a new tx/rx
      stop the radio with vMMAC_RadioToOffAndWait() to prevent unexpected events

    check for ongoing Rx before Tx
     improve Rx chances
     wait at most 544 symbols: 2 max length frames + AIFS

    increase marging for CSL rx
     OPENTHREAD_CONFIG_CSL_RECEIVE_TIME_AHEAD = 1920
```