### PR TITLE
k32w0: alarm: fix format specifier

### DIFF
--- a/src/k32w0/platform/alarm.c
+++ b/src/k32w0/platform/alarm.c
@@ -219,7 +219,7 @@ void alarmStartAt(TMR_tsActivityWakeTimerEvent *t, void (*cb)(void), bool *ev, u
     {
         now = otPlatAlarmMicroGetNow();
     }
-    otLogInfoPlat("Start timer: timestamp:%d, aTo:%d, aDt:%d", now, t0, dt);
+    otLogInfoPlat("Start timer: timestamp:%ld, aTo:%ld, aDt:%ld", now, t0, dt);
 
     /* Check 'now' position in range [t0, t1] */
     if ((now - t0 <= dt) && (t1 - now <= dt))


### PR DESCRIPTION
The bump to latest openthread commit will lead to a format specifier error.
See: https://github.com/project-chip/connectedhomeip/actions/runs/3393654583/jobs/5641258494

This PR updates the openthread submodule and fixes the format specifier error.