### PR TITLE
K32W0 SDK 2.6.11 changes

### DIFF
--- a/src/k32w0/platform/ecdsa-nxp-ultrafast-p256.cpp
+++ b/src/k32w0/platform/ecdsa-nxp-ultrafast-p256.cpp
@@ -49,13 +49,13 @@ otError otPlatCryptoEcdsaGenerateKey(otPlatCryptoEcdsaKeyPair *aKeyPair)
     ecp256KeyPair_t keypair;
     int             ret;
 
-    ret = ECP256_GenerateKeyPair(&keypair.public_key, &keypair.private_key);
+    ret = ECP256_GenerateKeyPair(&keypair.public_key, &keypair.private_key, NULL);
     VerifyOrExit(ret == gSecEcp256Success_c);
 
-    memcpy(aKeyPair->mDerBytes, &keypair.public_key, 2 * ECP256_COORDINATE_LEN);
-    memcpy(aKeyPair->mDerBytes + (2 * ECP256_COORDINATE_LEN), &keypair.private_key, ECP256_COORDINATE_LEN);
+    memcpy(aKeyPair->mDerBytes, &keypair.public_key, 2 * SEC_ECP256_COORDINATE_LEN);
+    memcpy(aKeyPair->mDerBytes + (2 * SEC_ECP256_COORDINATE_LEN), &keypair.private_key, SEC_ECP256_COORDINATE_LEN);
 
-    aKeyPair->mDerLength = static_cast<uint8_t>(3 * ECP256_COORDINATE_LEN);
+    aKeyPair->mDerLength = static_cast<uint8_t>(3 * SEC_ECP256_COORDINATE_LEN);
 
 exit:
     return (ret >= 0) ? kErrorNone : MbedTls::MapError(ret);
@@ -63,7 +63,7 @@ exit:
 
 otError otPlatCryptoEcdsaGetPublicKey(const otPlatCryptoEcdsaKeyPair *aKeyPair, otPlatCryptoEcdsaPublicKey *aPublicKey)
 {
-    memcpy(aPublicKey->m8, aKeyPair->mDerBytes, 2 * ECP256_COORDINATE_LEN);
+    memcpy(aPublicKey->m8, aKeyPair->mDerBytes, 2 * SEC_ECP256_COORDINATE_LEN);
 
 exit:
     return kErrorNone;
@@ -77,7 +77,8 @@ otError otPlatCryptoEcdsaSign(const otPlatCryptoEcdsaKeyPair *aKeyPair,
     ecp256KeyPair_t keypair;
     int             ret;
 
-    memcpy(keypair.private_key.raw_8bit, aKeyPair->mDerBytes + (2 * ECP256_COORDINATE_LEN), ECP256_COORDINATE_LEN);
+    memcpy(keypair.private_key.raw_8bit, aKeyPair->mDerBytes + (2 * SEC_ECP256_COORDINATE_LEN),
+           SEC_ECP256_COORDINATE_LEN);
 
     ret = ECDSA_SignFromHash(aSignature->m8, aHash->m8, Sha256::Hash::kSize, keypair.private_key.raw_8bit);
     VerifyOrExit(ret == gSecEcdsaSuccess_c, error = MbedTls::MapError(ret));

--- a/src/k32w0/platform/radio.c
+++ b/src/k32w0/platform/radio.c
@@ -105,10 +105,38 @@ extern void BOARD_GetCoexIoCfg(void **rfDeny, void **rfActive, void **rfStatus);
 #endif
 
 /* check IEEE Std. 802.15.4 - 2015: Table 8-81 - MAC sublayer constants */
+#ifndef MAC_TX_RETRIES
 #define MAC_TX_RETRIES (3)
+#endif
+
+#ifndef MAC_TX_CSMA_MIN_BE
 #define MAC_TX_CSMA_MIN_BE (3)
+#endif
+
+#ifndef MAC_TX_CSMA_MAX_BE
 #define MAC_TX_CSMA_MAX_BE (5)
+#endif
+
+#ifndef MAC_TX_CSMA_MAX_BACKOFFS
 #define MAC_TX_CSMA_MAX_BACKOFFS (4)
+#endif
+
+/* Ensure MAC sublayer constants adhere to the spec ranges. */
+#if (MAC_TX_RETRIES < 0) || (MAC_TX_RETRIES > 7)
+#error "MAC_TX_RETRIES must be in range [0, 7]"
+#endif
+
+#if (MAC_TX_CSMA_MIN_BE < 0) || (MAC_TX_CSMA_MIN_BE > MAC_TX_CSMA_MAX_BE)
+#error "MAC_TX_CSMA_MIN_BE must be in range [0, MAC_TX_CSMA_MAX_BE]"
+#endif
+
+#if (MAC_TX_CSMA_MAX_BE < 3) || (MAC_TX_CSMA_MAX_BE > 8)
+#error "MAC_TX_CSMA_MAX_BE must be in range [3, 8]"
+#endif
+
+#if (MAC_TX_CSMA_MAX_BACKOFFS < 0) || (MAC_TX_CSMA_MAX_BACKOFFS > 5)
+#error "MAC_TX_CSMA_MAX_BACKOFFS must be in range [0, 5]"
+#endif
 
 #define TX_TO 544 /* symbols. 2 max length frames + AIFS */
 


### PR DESCRIPTION
This PR includes the changes needed for K32W0 SDK 2.6.11.

Changelog
* k32w0: radio: configurable MAC sublayer constants
* k32w0: nxp-ultrafast-p256: update SDK API usage

Signed-off-by: Marius Tache <marius.tache@nxp.com>