### PR TITLE
update `spinel_hdlc.cpp` to use the latest RadioSpinel API

### DIFF
--- a/src/imx_rt/platform/radio.cpp
+++ b/src/imx_rt/platform/radio.cpp
@@ -34,12 +34,16 @@
 
 #include "ot_platform_common.h"
 
+#include <openthread/logging.h>
 #include <openthread/platform/radio.h>
 
 #include "spinel_hdlc.hpp"
+#include <lib/platform/exit_code.h>
 #include <lib/spinel/radio_spinel.hpp>
 
-static ot::Spinel::RadioSpinel<ot::RT::HdlcInterface> sRadioSpinel;
+static ot::Url::Url            sUrl;
+static ot::RT::HdlcInterface   sSpinelInterface(sUrl);
+static ot::Spinel::RadioSpinel sRadioSpinel;
 
 void otPlatRadioGetIeeeEui64(otInstance *aInstance, uint8_t *aIeeeEui64)
 {
@@ -361,8 +365,7 @@ otRadioState otPlatRadioGetState(otInstance *aInstance)
 
 void otPlatRadioInit(void)
 {
-    sRadioSpinel.GetSpinelInterface().Init();
-    sRadioSpinel.Init(true, false);
+    sRadioSpinel.Init(sSpinelInterface, true, false);
 }
 
 void otPlatRadioDeinit(void)

--- a/src/imx_rt/platform/spinel_hdlc.cpp
+++ b/src/imx_rt/platform/spinel_hdlc.cpp
@@ -89,25 +89,33 @@ namespace ot {
 
 namespace RT {
 
-HdlcInterface::HdlcInterface(ot::Spinel::SpinelInterface::ReceiveFrameCallback aCallback,
-                             void                                             *aCallbackContext,
-                             ot::Spinel::SpinelInterface::RxFrameBuffer       &aFrameBuffer)
-    : mReceiveFrameCallback(aCallback)
-    , mReceiveFrameContext(aCallbackContext)
-    , mReceiveFrameBuffer(aFrameBuffer)
+HdlcInterface::HdlcInterface(const Url::Url &aRadioUrl)
+    : mReceiveFrameCallback(nullptr)
+    , mReceiveFrameContext(nullptr)
+    , mReceiveFrameBuffer(nullptr)
     , encoderBuffer()
     , mHdlcEncoder(encoderBuffer)
-    , mHdlcDecoder(aFrameBuffer, HandleHdlcFrame, this)
+    , mHdlcDecoder()
 {
+    OT_UNUSED_VARIABLE(aRadioUrl);
 }
 
 HdlcInterface::~HdlcInterface(void)
 {
 }
 
-void HdlcInterface::Init(void)
+otError HdlcInterface::Init(ot::Spinel::SpinelInterface::ReceiveFrameCallback aCallback,
+                            void                                             *aCallbackContext,
+                            ot::Spinel::SpinelInterface::RxFrameBuffer       &aFrameBuffer)
 {
+    mReceiveFrameCallback = aCallback;
+    mReceiveFrameContext  = aCallbackContext;
+    mReceiveFrameBuffer   = &aFrameBuffer;
+    mHdlcDecoder.Init(aFrameBuffer, HandleHdlcFrame, this);
+
     InitUart();
+
+    return OT_ERROR_NONE;
 }
 
 void HdlcInterface::Deinit(void)
@@ -237,7 +245,7 @@ void HdlcInterface::HandleHdlcFrame(otError aError)
     else
     {
         OT_PLAT_DBG_NO_FUNC("Frame will be discarded error = 0x%x", aError);
-        mReceiveFrameBuffer.DiscardFrame();
+        mReceiveFrameBuffer->DiscardFrame();
     }
 }
 


### PR DESCRIPTION
OpenThread has changed the API of the RadioSpinel. It causes the issue https://github.com/openthread/ot-nxp/issues/608. This commit updates the `spinel_hdlc.cpp` to use the latest API and update the OpenThread source code to the latest .