### PR TITLE
K32W0 SDK 2.6.13 changes

### DIFF
--- a/script/build_k32w061
+++ b/script/build_k32w061
@@ -74,7 +74,7 @@ sign()
     if [ "$SDK_RELEASE" == "ON" ]; then
         "$NXP_K32W0_SDK_ROOT"/tools/imagetool/sign_images.sh "$1"
     else
-        "$NXP_K32W0_SDK_ROOT"/middleware/wireless/openthread/boards/dk6_jn5189/enablement/sign_images.sh "$1" "$NXP_K32W0_SDK_ROOT"/tools/imagetool
+        "$NXP_K32W0_SDK_ROOT"/middleware/wireless/openthread/boards/dk6_jn5189/enablement/sign_images.sh "$1" "$NXP_SIGN_ADDITIONAL_ARGS" "$NXP_K32W0_SDK_ROOT"/tools/imagetool
     fi
 }
 
@@ -114,7 +114,7 @@ build_ot_rcp_only_uart_flow_control()
     build "${options[@]}"
 
     #Sign the image
-    sign "${BUILD_DIR}/${app_folder_name}/openthread/examples/apps/ncp/"
+    sign "${BUILD_DIR}/${app_folder_name}/bin/"
 
     if [ $? -eq 1 ]; then
         exit 1
@@ -133,7 +133,7 @@ build_ot_rcp_only_spi()
     build "${options[@]}"
 
     #Sign the image
-    sign "${BUILD_DIR}/${app_folder_name}/openthread/examples/apps/ncp/"
+    sign "${BUILD_DIR}/${app_folder_name}/bin/"
 
     if [ $? -eq 1 ]; then
         exit 1
@@ -154,7 +154,7 @@ build_ot_without_rcp_image()
     build "${options[@]}"
 
     #Sign the image
-    sign "${BUILD_DIR}/openthread/examples/apps/cli/"
+    sign "${BUILD_DIR}/bin"
 
     if [ $? -eq 1 ]; then
         exit 1
@@ -201,6 +201,12 @@ main()
     fi
 
     echo "NXP_K32W0_SDK_ROOT set to $NXP_K32W0_SDK_ROOT"
+
+    if [ -z "$NXP_SIGN_ADDITIONAL_ARGS" ]; then
+        echo "NXP_SIGN_ADDITIONAL_ARGS not set. No additional args will be added to the sign command"
+    else
+        echo "NXP_SIGN_ADDITIONAL_ARGS set to $NXP_SIGN_ADDITIONAL_ARGS"
+    fi
 
     if [ $# == 0 ]; then
         create_directory_and_build all $SDK_RELEASE "$@"

--- a/src/common/ram_storage.c
+++ b/src/common/ram_storage.c
@@ -69,6 +69,12 @@ rsError ramStorageAdd(ramBufferDescriptor *pBuffer, uint16_t aKey, const uint8_t
     assert(pBuffer->buffer);
     otEXPECT_ACTION(pBuffer->header.length + newBlockLength <= pBuffer->header.maxLength, error = RS_ERROR_NO_BUFS);
 
+    if (pBuffer->header.extendedSearch == FALSE)
+    {
+        otEXPECT_ACTION(pBuffer->header.length + newBlockLength < pBuffer->header.backendRegionSize,
+                        error = RS_ERROR_NO_BUFS);
+    }
+
     error = ramStorageEnsureBlockConsistency(pBuffer, aValueLength);
     otEXPECT(error == RS_ERROR_NONE);
 

--- a/src/common/ram_storage.h
+++ b/src/common/ram_storage.h
@@ -44,12 +44,22 @@ typedef enum
 /* Header for a RAM buffer descriptor.
  * length: actual RAM buffer length (currently occupied with settingsBlock + data pairs).
  * maxLength: total allocated memory for RAM buffer (without header).
+ * extendedSearch: If false, the RAM buffer is limited to persistent storage
+ *                 backend region size.
+ *                 If true, the extended search feature is enabled. This means
+ *                 that a RAM buffer can span across multiple backend regions.
+ *                 Note: backend can be any persistent storage filesystem (e.g. PDM).
+ * backendRegionSize: If extendedSearch is false, it is used to limit the length of
+ *                    the buffer.
+ *                    If extendedSearch is true, it is ignored.
  * mutexHandle: mutex that protects RAM buffer operations.
  */
 typedef struct
 {
     uint16_t length;
     uint16_t maxLength;
+    bool_t   extendedSearch;
+    uint16_t backendRegionSize;
 #if PDM_SAVE_IDLE
     osaMutexId_t mutexHandle;
 #endif

--- a/src/k32w0/jn5189/openthread-core-jn5189-config.h
+++ b/src/k32w0/jn5189/openthread-core-jn5189-config.h
@@ -127,6 +127,18 @@
 #define OPENTHREAD_CONFIG_COMMISSIONER_ENABLE 1
 #endif
 
+/* Increase default timeout (30s) because k32w0 commissioner doesn't have crypto acceleration */
+/**
+ * @def OPENTHREAD_CONFIG_COMMISSIONER_JOINER_SESSION_TIMEOUT
+ *
+ * The timeout for the Joiner's session, in seconds. After this timeout,
+ * the Commissioner tears down the session.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_COMMISSIONER_JOINER_SESSION_TIMEOUT
+#define OPENTHREAD_CONFIG_COMMISSIONER_JOINER_SESSION_TIMEOUT 180
+#endif
+
 /**
  * @def OPENTHREAD_CONFIG_UDP_FORWARD_ENABLE
  *

--- a/src/k32w0/k32w061/openthread-core-k32w061-config.h
+++ b/src/k32w0/k32w061/openthread-core-k32w061-config.h
@@ -135,6 +135,18 @@
 #define OPENTHREAD_CONFIG_COMMISSIONER_ENABLE 1
 #endif
 
+/* Increase default timeout (30s) because k32w0 commissioner doesn't have crypto acceleration */
+/**
+ * @def OPENTHREAD_CONFIG_COMMISSIONER_JOINER_SESSION_TIMEOUT
+ *
+ * The timeout for the Joiner's session, in seconds. After this timeout,
+ * the Commissioner tears down the session.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_COMMISSIONER_JOINER_SESSION_TIMEOUT
+#define OPENTHREAD_CONFIG_COMMISSIONER_JOINER_SESSION_TIMEOUT 180
+#endif
+
 /**
  * @def OPENTHREAD_CONFIG_UDP_FORWARD_ENABLE
  *

--- a/src/k32w0/platform/flash_pdm.c
+++ b/src/k32w0/platform/flash_pdm.c
@@ -90,12 +90,16 @@ void otPlatSettingsInit(otInstance *aInstance, const uint16_t *aSensitiveKeys, u
     OT_UNUSED_VARIABLE(aSensitiveKeysLength);
     otError error = OT_ERROR_NONE;
 
+    otEXPECT_ACTION((TRUE == PDM_RetrieveSegmentSize()), error = OT_ERROR_NO_BUFS);
+
 #if PDM_SAVE_IDLE
     /* settings may have been already initialized:
      * e.g.: for PDM_SAVE_IDLE in XCVR context
      */
     if (settingsInitialized)
         return;
+
+    otEXPECT_ACTION((TRUE == FS_Init()), error = OT_ERROR_NO_BUFS);
 #endif
 
     otEXPECT_ACTION((PDM_E_STATUS_OK == PDM_Init()), error = OT_ERROR_NO_BUFS);
@@ -115,6 +119,8 @@ exit:
         {
             mutex_destroy(pdmMutexHandle);
         }
+
+        FS_Deinit();
     }
     else
     {
@@ -143,6 +149,10 @@ void otPlatSettingsDeinit(otInstance *aInstance)
 
     otPlatFree(ramDescr);
     ramDescr = NULL;
+#endif
+
+#if PDM_SAVE_IDLE
+    FS_Deinit();
 #endif
 }
 

--- a/src/k32w0/platform/pdm_ram_storage_glue.h
+++ b/src/k32w0/platform/pdm_ram_storage_glue.h
@@ -57,6 +57,9 @@ extern "C" {
 rsError ramStorageResize(ramBufferDescriptor *pBuffer, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength);
 #endif
 
+/* Wrapper over PDM_GetSegmentBufferSize. */
+bool_t PDM_RetrieveSegmentSize();
+
 /* Return a RAM buffer with initialSize and populated with the contents of NVM ID - if found in flash
  * Main use case is for dynamic memory allocation
  * In case static memory allocation is used, initialSize is unused
@@ -64,6 +67,8 @@ rsError ramStorageResize(ramBufferDescriptor *pBuffer, uint16_t aKey, const uint
 ramBufferDescriptor *getRamBuffer(uint16_t nvmId, uint16_t initialSize, bool_t extendedSearch);
 
 #if PDM_SAVE_IDLE
+bool_t       FS_Init();
+void         FS_Deinit();
 PDM_teStatus FS_eSaveRecordDataInIdleTask(uint16_t u16IdValue, ramBufferDescriptor *pvDataBuffer);
 void         FS_vIdleTask(uint8_t u8WritesAllowed);
 bool_t       idleMutexIsTaken();

--- a/third_party/k32w061_sdk/repo/manifest/west.yml
+++ b/third_party/k32w061_sdk/repo/manifest/west.yml
@@ -12,7 +12,7 @@ manifest:
     remote: nxpmicro
   projects:
   - name: mcux-sdk
-    revision: b1ce670e8433142a3c78dca7f4597326eb5f5342
+    revision: 7219c54f5dbd5a8636242f9f1771ddb70be146c9
     path: core
   - name: amazon-freertos
     url: https://github.com/NXP/amazon-freertos.git
@@ -24,7 +24,7 @@ manifest:
     revision: 15458495823165de372f62c3dad621a8da6c86e3
   - name: framework
     url: https://github.com/NXP/mcux-sdk-middleware-connectivity-framework.git
-    revision: a45ed24bc5f8d54312c4d9243c4423d226084412
+    revision: 2ccc3df70ee5b73c451fceee13e6172518412518
     path: core/middleware/wireless/framework   
   - name: ble_controller
     url: https://github.com/NXP/mcux-sdk-middleware-bluetooth-controller.git
@@ -36,13 +36,13 @@ manifest:
     path: core/middleware/wireless/bluetooth
   - name: ieee-802.15.4
     url: https://github.com/NXP/mcux-sdk-middleware-ieee_802.15.4.git
-    revision: 7cca871d58e53c78a703a39b269c4366b03f26e4
+    revision: e8c96197346a7e37ce3a872096a22bf4aee47e3d
     path: core/middleware/wireless/ieee-802.15.4
   - name: zigbee
     url: https://github.com/nxp-mcuxpresso/mcux-sdk-middleware-zigbee.git
-    revision: ef9636fafec2c76fa12d7ebe910b9925733b8ed0
+    revision: 77dc56b1e2d8fabe66361702ce45fc989dbd7940
     path: core/middleware/wireless/zigbee
   - name: examples
     url: https://github.com/nxp-mcuxpresso/mcux-sdk-examples.git
-    revision: 39eed09d6a8485dcf365a24cd6ef957e7cc6fbf8
+    revision: 6735550f5a41dfb997d4dd3ce6eebfe1f1d41054
     path: core/boards


### PR DESCRIPTION
Changelog:
* Add extended search feature.
* Limit temporary RAM buffer to PDM page size.
* Radio: fix VS IE content.
* Adjust RSSI to be [-110, 0].
* Update west manifest to point to 2.6.13.
* Sync with the sign_images script changes.

Signed-off-by: George Stefan [george.stefan@nxp.com](mailto:george.stefan@nxp.com)
Signed-off-by: Marius Tache [marius.tache@nxp.com](mailto:marius.tache@nxp.com)